### PR TITLE
Turn off JDK install by default

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,3 +2,4 @@
 schema_registry_rpm_repo_key: "http://packages.confluent.io/rpm/2.0/archive.key"
 schema_registry_rpm_repo: "http://packages.confluent.io/rpm/2.0"
 schema_registry_rpm: "confluent-schema-registry=2.0.1-1"
+install_jdk: false

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,6 +2,7 @@
 - name: Install JDK
   zypper:
     name: "{{ jdk_package }}"
+  when: "{{ install_jdk }} is true"
 
 - name: Import Schema Registry Repository Public Key
   rpm_key:


### PR DESCRIPTION
At least in the context of this role, Java should be installed separately despite being a requirement for Schema Registry.